### PR TITLE
Swap out BearerAuth for OAuth2 in spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "2.2.42",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-matchmaker-api",
-      "version": "2.2.42",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "2.2.42",
+  "version": "2.3.0",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/controllers/v1/attachment/index.ts
+++ b/src/controllers/v1/attachment/index.ts
@@ -59,7 +59,7 @@ const parseAccept = (acceptHeader: string) =>
 
 @Route('v1/attachment')
 @Tags('attachment')
-@Security('BearerAuth')
+@Security('oauth2')
 export class attachment extends Controller {
   log: Logger
   db: Database = new Database()

--- a/src/controllers/v1/demandA/index.ts
+++ b/src/controllers/v1/demandA/index.ts
@@ -16,7 +16,7 @@ import Identity from '../../../lib/services/identity.js'
 @Route('v1/demandA')
 @injectable()
 @Tags('demandA')
-@Security('BearerAuth')
+@Security('oauth2')
 export class DemandAController extends DemandController {
   constructor(identity: Identity) {
     super('demandA', identity)

--- a/src/controllers/v1/demandB/index.ts
+++ b/src/controllers/v1/demandB/index.ts
@@ -16,7 +16,7 @@ import Identity from '../../../lib/services/identity.js'
 @Route('v1/demandB')
 @injectable()
 @Tags('demandB')
-@Security('BearerAuth')
+@Security('oauth2')
 export class DemandBController extends DemandController {
   constructor(identity: Identity) {
     super('demandB', identity)

--- a/src/controllers/v1/match2/index.ts
+++ b/src/controllers/v1/match2/index.ts
@@ -38,7 +38,7 @@ import { parseDateParam } from '../../../lib/utils/queryParams.js'
 @Route('v1/match2')
 @injectable()
 @Tags('match2')
-@Security('BearerAuth')
+@Security('oauth2')
 export class Match2Controller extends Controller {
   log: Logger
   db: Database

--- a/src/controllers/v1/transaction/index.ts
+++ b/src/controllers/v1/transaction/index.ts
@@ -10,7 +10,7 @@ import { parseDateParam } from '../../../lib/utils/queryParams.js'
 
 @Route('v1/transaction')
 @Tags('transaction')
-@Security('BearerAuth')
+@Security('oauth2')
 export class TransactionController extends Controller {
   log: Logger
   db: Database

--- a/tsoa.json
+++ b/tsoa.json
@@ -13,10 +13,9 @@
     "outputDirectory": "src",
     "specVersion": 3,
     "securityDefinitions": {
-      "BearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {}
       }
     },
     "specMerging": "recursive",


### PR DESCRIPTION
Related to L3-230. This swaps out support for BearerAuth type authentication for Oauth2 now we're looking to use keycloak as an auth broker. Note this does not affect the way auth is handled by the application just how it is presented in the spec. The plan in time is to add scopes to each route so we can have a more fine grained approach