### PR TITLE
Fix IDP path vars to be strings not urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-matchmaker-api",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/env.ts
+++ b/src/env.ts
@@ -35,10 +35,10 @@ export default envalid.cleanEnv(process.env, {
   IDP_INTERNAL_URL_PREFIX: envalid.url({
     devDefault: 'http://localhost:3080/realms/member-a/protocol/openid-connect',
   }),
-  IDP_TOKEN_PATH: envalid.url({
+  IDP_TOKEN_PATH: envalid.str({
     default: '/token',
   }),
-  IDP_JWKS_PATH: envalid.url({
+  IDP_JWKS_PATH: envalid.str({
     default: '/certs',
   }),
 })


### PR DESCRIPTION
Ticket: [sqnc-6](https://digicatapult.atlassian.net/browse/SQNC-6)

They are not urls and this causes issues in parsing
