### PR TITLE
Add limit of 200000 blocks to be processed to prevent OOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.0.79",
+  "version": "3.0.80",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-matchmaker-api",
-      "version": "3.0.79",
+      "version": "3.0.80",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.42",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.0.79",
+  "version": "3.0.80",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/lib/indexer/index.ts
+++ b/src/lib/indexer/index.ts
@@ -158,7 +158,13 @@ export default class Indexer {
     const newHashes = [lastFinalisedHash]
     for (let i = lastFinalisedIndex; i > lastKnownIndex + 1; i--) {
       const lastChild = await this.node.getHeader(newHashes.at(-1) as HEX)
+      this.logger.trace('Found block %s at height %d', lastChild.parent, lastChild.height)
       newHashes.push(lastChild.parent)
+
+      if (newHashes.length > 200000) {
+        this.logger.debug('Detected greater more than 200,000 blocks to process. Truncating to 100,000')
+        newHashes.splice(0, 100000)
+      }
     }
 
     // sanity check that the parent of lastKnown index is indeed what we expect. If not we have a major problem


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

SQNC-17

## High level description

Fixes an issue that can be git in the indexer if the list of processed blocks is extremely large, leading to OOM.

## Detailed description

If the matchmaker has a very large number of blocks to process (> 1e6) it can run out of memory. This change limits the number of blocks it will actually process to 200,000 at the expense of needing to re-run the check for new blocks multiple times

## Describe alternatives you've considered

A better solution would be to change how we use `processed_blocks` so we store all the blocks that are pending and then just mark them as processed. This would be a larger change however.

## Operational impact

Might make the `order` have invalid data if something is wrong but this persona currently has no data of value in it. If this goes wrong we'll need to truncate the `processed_blocks` table there 

## Additional context

none