### PR TITLE
Fix a bug whereby too many node connections are created under high load leading to 429s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@digicatapult/tsoa-oauth-express": "^0.1.69",
         "@polkadot/api": "^14.3.1",
         "@tsoa/runtime": "^6.5.1",
+        "async-mutex": "^0.5.0",
         "base-x": "^5.0.0",
         "body-parser": "^1.20.3",
         "cors": "^2.8.5",
@@ -3105,6 +3106,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -10607,6 +10617,14 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true
+    },
+    "async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "multer": "^1.4.5-lts.1",
         "pg": "^8.13.1",
         "pino": "^9.5.0",
+        "reflect-metadata": "^0.2.2",
         "swagger-ui-express": "^5.0.1",
         "tsoa": "^6.5.1",
         "tsyringe": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.0.136",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-matchmaker-api",
-      "version": "3.0.136",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.69",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "multer": "^1.4.5-lts.1",
     "pg": "^8.13.1",
     "pino": "^9.5.0",
+    "reflect-metadata": "^0.2.2",
     "swagger-ui-express": "^5.0.1",
     "tsoa": "^6.5.1",
     "tsyringe": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@digicatapult/tsoa-oauth-express": "^0.1.69",
     "@polkadot/api": "^14.3.1",
     "@tsoa/runtime": "^6.5.1",
+    "async-mutex": "^0.5.0",
     "base-x": "^5.0.0",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.0.136",
+  "version": "3.1.0",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -14,7 +14,7 @@ const exampleOptions: AuthOptions = {
     const scopes = ((decoded as jwt.JwtPayload).scopes as string) || ''
     return scopes.split(' ')
   },
-  tryRefreshTokens: (_req: express.Request) => Promise.resolve(false),
+  tryRefreshTokens: () => Promise.resolve(false),
 }
 
 export const expressAuthentication = mkExpressAuthentication(exampleOptions)

--- a/src/controllers/v1/attachment/index.ts
+++ b/src/controllers/v1/attachment/index.ts
@@ -161,7 +161,8 @@ export class attachment extends Controller {
             const json = JSON.parse(blobBuffer.toString())
             return json
           } catch (err) {
-            this.log.warn(`Unable to parse json file for attachment ${id}`)
+            this.log.warn('Unable to parse json file for attachment %s', id)
+            this.log.debug('Parse error: %s', err instanceof Error ? err.message : 'unknown')
             return this.octetResponse(blobBuffer, filename)
           }
         }

--- a/src/controllers/v1/demandA/index.ts
+++ b/src/controllers/v1/demandA/index.ts
@@ -27,14 +27,15 @@ import { BadRequest, NotFound } from '../../../lib/error-handler/index.js'
 import { TransactionResponse } from '../../../models/transaction.js'
 import { DemandController } from '../_common/demand.js'
 import Identity from '../../../lib/services/identity.js'
+import ChainNode from '../../../lib/chainNode.js'
 
 @Route('v1/demandA')
 @injectable()
 @Tags('demandA')
 @Security('oauth2')
 export class DemandAController extends DemandController {
-  constructor(identity: Identity) {
-    super('demandA', identity)
+  constructor(identity: Identity, node: ChainNode) {
+    super('demandA', identity, node)
   }
 
   /**

--- a/src/controllers/v1/demandB/index.ts
+++ b/src/controllers/v1/demandB/index.ts
@@ -27,14 +27,15 @@ import { BadRequest, NotFound } from '../../../lib/error-handler/index.js'
 import { TransactionResponse } from '../../../models/transaction.js'
 import { DemandController } from '../_common/demand.js'
 import Identity from '../../../lib/services/identity.js'
+import ChainNode from '../../../lib/chainNode.js'
 
 @Route('v1/demandB')
 @injectable()
 @Tags('demandB')
 @Security('oauth2')
 export class DemandBController extends DemandController {
-  constructor(identity: Identity) {
-    super('demandB', identity)
+  constructor(identity: Identity, node: ChainNode) {
+    super('demandB', identity, node)
   }
 
   /**

--- a/src/controllers/v1/match2/index.ts
+++ b/src/controllers/v1/match2/index.ts
@@ -42,7 +42,6 @@ import {
   rematch2AcceptFinal,
 } from '../../../lib/payload.js'
 import ChainNode from '../../../lib/chainNode.js'
-import env from '../../../env.js'
 import { parseDateParam } from '../../../lib/utils/queryParams.js'
 import { getAuthorization } from '../../../lib/utils/shared.js'
 
@@ -53,19 +52,14 @@ import { getAuthorization } from '../../../lib/utils/shared.js'
 export class Match2Controller extends Controller {
   log: Logger
   db: Database
-  node: ChainNode
 
-  constructor(private identity: Identity) {
+  constructor(
+    private identity: Identity,
+    private node: ChainNode
+  ) {
     super()
     this.log = logger.child({ controller: '/match2' })
     this.db = new Database()
-    this.node = new ChainNode({
-      host: env.NODE_HOST,
-      port: env.NODE_PORT,
-      logger,
-      userUri: env.USER_URI,
-    })
-    this.identity = identity
   }
 
   /**

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,6 @@
 import * as envalid from 'envalid'
 import dotenv from 'dotenv'
+import { container } from 'tsyringe'
 
 if (process.env.NODE_ENV === 'test') {
   dotenv.config({ path: 'test/test.env' })
@@ -7,7 +8,7 @@ if (process.env.NODE_ENV === 'test') {
   dotenv.config()
 }
 
-export default envalid.cleanEnv(process.env, {
+const env = envalid.cleanEnv(process.env, {
   PORT: envalid.port({ default: 3000 }),
   LOG_LEVEL: envalid.str({ default: 'info', devDefault: 'debug' }),
   DB_HOST: envalid.str({ devDefault: 'localhost' }),
@@ -41,4 +42,13 @@ export default envalid.cleanEnv(process.env, {
   IDP_JWKS_PATH: envalid.str({
     default: '/certs',
   }),
+})
+
+export default env
+
+export const EnvToken = Symbol('Env')
+export type Env = typeof env
+
+container.register<Env>(EnvToken, {
+  useValue: env,
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Express } from 'express'
+import { container } from 'tsyringe'
 
 import Indexer from './lib/indexer/index.js'
 import ChainNode from './lib/chainNode.js'
@@ -10,12 +11,7 @@ import { logger } from './lib/logger.js'
   const app: Express = await Server()
 
   if (env.ENABLE_INDEXER) {
-    const node = new ChainNode({
-      host: env.NODE_HOST,
-      port: env.NODE_PORT,
-      logger,
-      userUri: env.USER_URI,
-    })
+    const node = container.resolve(ChainNode)
 
     const indexer = new Indexer({ db: new Database(), logger, node })
     await indexer.start()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata'
+
 import { Express } from 'express'
 import { container } from 'tsyringe'
 

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -1,8 +1,18 @@
 import { IocContainer } from '@tsoa/runtime'
 import { container } from 'tsyringe'
+import { Logger } from 'pino'
+
+import env, { type Env, EnvToken } from './env.js'
+import { logger, LoggerToken } from './lib/logger.js'
 
 export const iocContainer: IocContainer = {
   get: <T>(controller: { prototype: T }): T => {
     return container.resolve<T>(controller as never)
   },
+}
+
+export function resetContainer() {
+  container.reset()
+  container.register<Env>(EnvToken, { useValue: env })
+  container.register<Logger>(LoggerToken, { useValue: logger })
 }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -287,7 +287,7 @@ export default class Database {
       .returning(transactionColumns)
   }
 
-  getTransaction = async (id: UUID) => {
+  getTransaction = async (id: UUID): Promise<[Transaction] | []> => {
     return this.db().transaction().select(transactionColumns).where({ id })
   }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,7 @@
 import { pino, Logger } from 'pino'
 
 import env from '../env.js'
+import { container } from 'tsyringe'
 
 export const logger: Logger = pino(
   {
@@ -10,3 +11,6 @@ export const logger: Logger = pino(
   },
   process.stdout
 )
+
+export const LoggerToken = Symbol('Logger')
+container.register<Logger>(LoggerToken, { useValue: logger })

--- a/src/lib/service-watcher/apiStatus.ts
+++ b/src/lib/service-watcher/apiStatus.ts
@@ -1,15 +1,10 @@
 import { startStatusHandler } from './statusPoll.js'
 import env from '../../env.js'
 import ChainNode from '../chainNode.js'
-import { logger } from '../logger.js'
+import { container } from 'tsyringe'
 
 const { WATCHER_POLL_PERIOD_MS, WATCHER_TIMEOUT_MS } = env
-const node = new ChainNode({
-  host: env.NODE_HOST,
-  port: env.NODE_PORT,
-  logger,
-  userUri: env.USER_URI,
-})
+const node = container.resolve(ChainNode)
 
 const startApiStatus = () =>
   startStatusHandler({

--- a/src/lib/service-watcher/statusPoll.ts
+++ b/src/lib/service-watcher/statusPoll.ts
@@ -1,3 +1,5 @@
+import { logger } from '../logger.js'
+
 export const serviceState = {
   UP: 'up',
   DOWN: 'down',
@@ -51,6 +53,7 @@ const mkStatusGenerator = async function* ({
       }
       throw new Error('Status is not a valid value')
     } catch (err) {
+      logger.debug('Status generator error: %s', err instanceof Error ? err.message : 'unknown')
       yield {
         status: serviceState.ERROR,
         detail: null,

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { NotFound, HttpResponse } from '../error-handler/index.js'
 import env from '../../env.js'
 import { Status, serviceState } from '../service-watcher/statusPoll.js'
+import { logger } from '../logger.js'
 
 const identityResponseValidator = z.object({
   address: z.string(),
@@ -46,6 +47,7 @@ export default class Identity {
       }
       throw new Error()
     } catch (err) {
+      logger.debug('Identity service status error: %s', err instanceof Error ? err.message : 'unknown')
       return {
         status: serviceState.DOWN,
         detail: {

--- a/test/helper/chainTest.ts
+++ b/test/helper/chainTest.ts
@@ -7,26 +7,21 @@ import Indexer from '../../src/lib/indexer/index.js'
 import Database from '../../src/lib/db/index.js'
 import ChainNode from '../../src/lib/chainNode.js'
 import { logger } from '../../src/lib/logger.js'
-import env from '../../src/env.js'
+import { container } from 'tsyringe'
 
 const db = new Database()
 
 export const withAppAndIndexer = (context: { app: Express; indexer: Indexer }) => {
   before(async function () {
     context.app = await createHttpServer()
-    const node = new ChainNode({
-      host: env.NODE_HOST,
-      port: env.NODE_PORT,
-      logger,
-      userUri: env.USER_URI,
-    })
+    const node = container.resolve(ChainNode)
 
     const blockHash = await node.getLastFinalisedBlockHash()
     const blockHeader = await node.getHeader(blockHash)
     await db
       .insertProcessedBlock({
         hash: blockHash,
-        height: blockHeader.height,
+        height: blockHeader.height.toString(10),
         parent: blockHash,
       })
       .catch(() => {

--- a/test/helper/poll.ts
+++ b/test/helper/poll.ts
@@ -1,24 +1,44 @@
 import Database from '../../src/lib/db/index.js'
-import { TransactionResponse } from '../../src/models/transaction.js'
 import { UUID } from '../../src/models/strings.js'
 
 type Method = 'getTransaction' | 'getDemand' | 'getDemandCommentForTransaction' | 'getMatch2' extends keyof Database
   ? 'getTransaction' | 'getDemand' | 'getDemandCommentForTransaction' | 'getMatch2'
   : never
 
+const getRow = async (db: Database, method: Method, id: string): Promise<{ state: string } | undefined> => {
+  switch (method) {
+    case 'getTransaction': {
+      const [row] = await db.getTransaction(id)
+      return row
+    }
+    case 'getDemand': {
+      const [row] = await db.getDemand(id)
+      return row
+    }
+    case 'getDemandCommentForTransaction': {
+      const [row] = await db.getDemandCommentForTransaction(id)
+      return row
+    }
+    case 'getMatch2': {
+      const [row] = await db.getMatch2(id)
+      return row
+    }
+  }
+}
+
 const pollState =
   (method: Method) =>
   async (db: Database, id: UUID | undefined, targetState: string, delay = 100, maxRetry = 100): Promise<void> => {
     let retry = 0
 
-    const poll = async (): Promise<TransactionResponse> => {
+    const poll = async (): Promise<void> => {
       if (retry >= maxRetry) {
         throw new Error(`Maximum number of retries exceeded while waiting for  ${id} to reach state ${targetState}`)
       }
 
-      const [row] = await db[method](id)
+      const row = await getRow(db, method, id || '')
       if (row && row.state === targetState) {
-        return row
+        return
       }
 
       retry += 1

--- a/test/helper/poll.ts
+++ b/test/helper/poll.ts
@@ -1,36 +1,35 @@
 import Database from '../../src/lib/db/index.js'
-import { TransactionState, TransactionResponse } from '../../src/models/transaction.js'
+import { TransactionResponse } from '../../src/models/transaction.js'
 import { UUID } from '../../src/models/strings.js'
 
-export const pollTransactionState = async (
-  db: Database,
-  transactionId: UUID,
-  targetState: TransactionState,
-  delay = 1000,
-  maxRetry = 30
-): Promise<TransactionResponse> => {
-  let retry = 0
+type Method = 'getTransaction' | 'getDemand' | 'getDemandCommentForTransaction' | 'getMatch2' extends keyof Database
+  ? 'getTransaction' | 'getDemand' | 'getDemandCommentForTransaction' | 'getMatch2'
+  : never
 
-  const poll = async (): Promise<TransactionResponse> => {
-    if (retry >= maxRetry) {
-      throw new Error(
-        `Maximum number of retries exceeded while waiting for transaction ${transactionId} to reach state ${targetState}`
-      )
+const pollState =
+  (method: Method) =>
+  async (db: Database, id: UUID | undefined, targetState: string, delay = 100, maxRetry = 100): Promise<void> => {
+    let retry = 0
+
+    const poll = async (): Promise<TransactionResponse> => {
+      if (retry >= maxRetry) {
+        throw new Error(`Maximum number of retries exceeded while waiting for  ${id} to reach state ${targetState}`)
+      }
+
+      const [row] = await db[method](id)
+      if (row && row.state === targetState) {
+        return row
+      }
+
+      retry += 1
+
+      return new Promise((resolve) => setTimeout(resolve, delay)).then(poll)
     }
 
-    const [transaction] = await db.getTransaction(transactionId)
-    if (transaction.state === targetState) {
-      return transaction
-    }
-
-    retry += 1
-
-    return new Promise((resolve) => setTimeout(resolve, delay)).then(poll)
+    await poll()
   }
 
-  return poll().then((value) => {
-    return new Promise((resolve) => {
-      setTimeout(() => resolve(value), delay)
-    })
-  })
-}
+export const pollTransactionState = pollState('getTransaction')
+export const pollDemandState = pollState('getDemand')
+export const pollDemandCommentState = pollState('getDemandCommentForTransaction')
+export const pollMatch2State = pollState('getMatch2')

--- a/test/init.ts
+++ b/test/init.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata'

--- a/test/integration/offchain/healthcheck.test.ts
+++ b/test/integration/offchain/healthcheck.test.ts
@@ -8,6 +8,7 @@ import createHttpServer from '../../../src/server.js'
 import { get } from '../../helper/routeHelper.js'
 import { responses as healthResponses } from '../../helper/healthHelper.js'
 import { withOkMock, withIpfsMockError } from '../../helper/mockHealth.js'
+import { resetContainer } from '../../../src/ioc.js'
 
 const getSpecVersion = (actualResult: any) => {
   return actualResult?._body?.details?.api?.detail?.runtime?.versions?.spec
@@ -32,7 +33,7 @@ describe('health check', () => {
     after(async function () {
       const serviceWatcher = container.resolve<ServiceWatcher>(ServiceWatcher)
       await serviceWatcher.close()
-      container.reset()
+      resetContainer()
     })
 
     it('health check', async function () {
@@ -57,7 +58,7 @@ describe('health check', () => {
     after(async function () {
       const serviceWatcher = container.resolve<ServiceWatcher>(ServiceWatcher)
       await serviceWatcher.close()
-      container.reset()
+      resetContainer()
     })
 
     withIpfsMockError()

--- a/test/integration/onchain/chain.test.ts
+++ b/test/integration/onchain/chain.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { describe } from 'mocha'
 import { Express } from 'express'
 import { expect } from 'chai'
@@ -51,7 +49,7 @@ describe('on-chain', function () {
       await node.sealBlock()
       await pollTransactionState(db, transaction.id, 'failed')
       const [failedTransaction] = await db.getTransaction(transaction.id)
-      expect(failedTransaction.state).to.equal('failed')
+      expect(failedTransaction?.state).to.equal('failed')
     })
   })
 })

--- a/test/integration/onchain/demandA.test.ts
+++ b/test/integration/onchain/demandA.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { describe, beforeEach, afterEach, it } from 'mocha'
 import { Express } from 'express'
 import { expect } from 'chai'

--- a/test/integration/onchain/demandB.test.ts
+++ b/test/integration/onchain/demandB.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { describe, beforeEach, afterEach, it } from 'mocha'
 import { Express } from 'express'
 import { expect } from 'chai'

--- a/test/integration/onchain/match2.test.ts
+++ b/test/integration/onchain/match2.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { describe, beforeEach, afterEach, it } from 'mocha'
 import { Express } from 'express'
 import { expect } from 'chai'

--- a/test/integration/onchain/match2.test.ts
+++ b/test/integration/onchain/match2.test.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata'
+
 import { describe, beforeEach, afterEach, it } from 'mocha'
 import { Express } from 'express'
 import { expect } from 'chai'
@@ -8,21 +10,15 @@ import { seed, cleanup, parametersAttachmentId } from '../../seeds/onchainSeeds/
 import { withIdentitySelfMock } from '../../helper/mock.js'
 import Database, { DemandRow, Match2Row, Transaction } from '../../../src/lib/db/index.js'
 import ChainNode from '../../../src/lib/chainNode.js'
-import { logger } from '../../../src/lib/logger.js'
-import env from '../../../src/env.js'
-import { pollTransactionState } from '../../helper/poll.js'
+import { pollDemandState, pollMatch2State, pollTransactionState } from '../../helper/poll.js'
 import { withAppAndIndexer } from '../../helper/chainTest.js'
 import { UUID } from '../../../src/models/strings.js'
+import { container } from 'tsyringe'
 
 describe('on-chain', function () {
   this.timeout(180000)
   const db = new Database()
-  const node = new ChainNode({
-    host: env.NODE_HOST,
-    port: env.NODE_PORT,
-    logger,
-    userUri: env.USER_URI,
-  })
+  const node = container.resolve(ChainNode)
   const context: { app: Express; indexer: Indexer } = {} as { app: Express; indexer: Indexer }
 
   withAppAndIndexer(context)
@@ -58,11 +54,13 @@ describe('on-chain', function () {
 
       await node.sealBlock()
       await pollTransactionState(db, demandATransactionId, 'finalised')
+      await pollDemandState(db, demandAId, 'created')
 
       const [demandA]: DemandRow[] = await db.getDemand(demandAId)
 
       await node.sealBlock()
       await pollTransactionState(db, demandBTransactionId, 'finalised')
+      await pollDemandState(db, demandBId, 'created')
 
       const [demandB]: DemandRow[] = await db.getDemand(demandBId)
 
@@ -76,6 +74,7 @@ describe('on-chain', function () {
 
       await node.sealBlock()
       await pollTransactionState(db, newDemandBTransactionId, 'finalised')
+      await pollDemandState(db, newDemandBId, 'created')
 
       const {
         body: { id: match2Id },
@@ -107,6 +106,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, transactionId, 'finalised')
+      await pollMatch2State(db, ids.match2, 'proposed')
 
       // check local entities update with token id
       const [maybeDemandA] = await db.getDemand(ids.demandA)
@@ -133,6 +133,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, proposal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'proposed')
 
       // submit accept to chain
       const responseAcceptA = await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
@@ -140,6 +141,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, responseAcceptA.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedA')
 
       // submit 2nd accept to chain
       const responseAcceptFinal = await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
@@ -147,6 +149,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, responseAcceptFinal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedFinal')
 
       const lastTokenId = await node.getLastTokenId()
 
@@ -171,6 +174,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, transactionId, 'finalised')
+      await pollMatch2State(db, ids.rematch2, 'proposed')
 
       // check local entities update with token id
       const [maybeDemandA] = await db.getDemand(ids.demandA)
@@ -202,16 +206,19 @@ describe('on-chain', function () {
       const proposal = await post(context.app, `/v1/match2/${ids.match2}/proposal`, {})
       await node.sealBlock()
       await pollTransactionState(db, proposal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'proposed')
 
       const resAcceptA = await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
 
       await node.sealBlock()
       await pollTransactionState(db, resAcceptA.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedA')
 
       const resAcceptFinal = await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
 
       await node.sealBlock()
       await pollTransactionState(db, resAcceptFinal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedFinal')
 
       const reMatch = await post(context.app, '/v1/match2', {
         demandA: ids.demandA,
@@ -224,17 +231,20 @@ describe('on-chain', function () {
 
       await node.sealBlock()
       await pollTransactionState(db, resProposal.body.id, 'finalised')
+      await pollMatch2State(db, ids.rematch2, 'proposed')
 
       const resRematchAccept = await post(context.app, `/v1/match2/${ids.rematch2}/accept`, {})
 
       await node.sealBlock()
       await pollTransactionState(db, resRematchAccept.body.id, 'finalised')
+      await pollMatch2State(db, ids.rematch2, 'acceptedA')
 
       const lastTokenId = await node.getLastTokenId()
       const resFinal = await post(context.app, `/v1/match2/${ids.rematch2}/accept`, {})
 
       await node.sealBlock()
       await pollTransactionState(db, resFinal.body.id, 'finalised')
+      await pollMatch2State(db, ids.rematch2, 'acceptedFinal')
 
       // output
       const [match2]: Match2Row[] = await db.getMatch2(ids.match2)
@@ -266,12 +276,14 @@ describe('on-chain', function () {
 
         await node.sealBlock()
         await pollTransactionState(db, proposal.body.id, 'finalised')
+        await pollMatch2State(db, ids.match2, 'proposed')
 
         const acceptA = await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
         await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
 
         await node.sealBlock()
         await pollTransactionState(db, acceptA.body.id, 'finalised')
+        await pollMatch2State(db, ids.match2, 'acceptedA')
 
         const { body: transactions } = await get(context.app, `/v1/match2/${ids.match2}/accept`)
         const failed = transactions.filter((el: Transaction) => el.state === 'failed')
@@ -300,6 +312,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, proposal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'proposed')
 
       const [maybeMatch2] = await db.getMatch2(ids.match2)
       const match2 = maybeMatch2 as Match2Row
@@ -313,6 +326,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, responseAcceptA.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedA')
 
       // check local entities update with token id
       const [maybeMatch2AcceptA] = await db.getMatch2(ids.match2)
@@ -328,6 +342,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, responseAcceptFinal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedFinal')
 
       // check local entities update with token id
       const [maybeDemandA] = await db.getDemand(ids.demandA)
@@ -357,6 +372,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, proposal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'proposed')
 
       const [maybeMatch2] = await db.getMatch2(ids.match2)
       const match2 = maybeMatch2 as Match2Row
@@ -369,6 +385,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, rejection.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'rejected')
 
       // check local entities update with token id
       const [maybeMatch2Rejected] = await db.getMatch2(ids.match2)
@@ -387,6 +404,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, proposal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'proposed')
 
       // acceptA
       const acceptA = await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
@@ -395,6 +413,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, acceptA.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedA')
 
       const [maybeMatch2] = await db.getMatch2(ids.match2)
       const match2 = maybeMatch2 as Match2Row
@@ -407,6 +426,7 @@ describe('on-chain', function () {
       // wait for block to finalise
       await node.sealBlock()
       await pollTransactionState(db, rejection.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'rejected')
 
       // check local entities update with token id
       const [maybeMatch2Rejected] = await db.getMatch2(ids.match2)
@@ -422,6 +442,7 @@ describe('on-chain', function () {
 
       await node.sealBlock()
       await pollTransactionState(db, proposal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'proposed')
 
       const { originalTokenId } = await db.getMatch2(ids.match2).then((el: Match2Row[]) => el[0])
 
@@ -429,11 +450,13 @@ describe('on-chain', function () {
 
       await node.sealBlock()
       await pollTransactionState(db, acceptA.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedA')
 
       const acceptFinal = await post(context.app, `/v1/match2/${ids.match2}/accept`, {})
 
       await node.sealBlock()
       await pollTransactionState(db, acceptFinal.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'acceptedFinal')
 
       const lastTokenId = await node.getLastTokenId()
 
@@ -443,6 +466,7 @@ describe('on-chain', function () {
 
       await node.sealBlock()
       await pollTransactionState(db, cancel.body.id, 'finalised')
+      await pollMatch2State(db, ids.match2, 'cancelled')
 
       const demandA: DemandRow = await db.getDemand(ids.demandA).then((rows: DemandRow[]) => rows[0])
       const demandB: DemandRow = await db.getDemand(ids.demandB).then((rows: DemandRow[]) => rows[0])

--- a/test/mocharc.json
+++ b/test/mocharc.json
@@ -2,7 +2,6 @@
   "timeout": 5000,
   "exit": true,
   "extension": "ts",
-  "node-option": [
-    "import=@digicatapult/tsimp/import"
-  ]
+  "file": ["test/init.ts"],
+  "node-option": ["import=@digicatapult/tsimp/import"]
 }


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-24

## High level description

Fix a bug whereby too many node connections are created under high load leading to 429s

## Detailed description

Adds a test for creating 500 demandAs in parrallel and then fixs exposed issues. Broadly speaking this is caused by each controller being instantiated for each request. This was then making a ChainNode per request and thus a polkadot instance. I've made `ChainNode` a singleton now to avoid this.

In order to make tests perform sensibly I've also improved the way we were polling for state changes

As a side effect we can also now load demands in parallel as long as we only have a single matchmaker

## Describe alternatives you've considered

None

## Operational impact

Should resolve the issues with the L3 deployment

## Additional context

None
