### PR TITLE
Set supported node version to 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,8 @@
         "undici": "^7.2.0"
       },
       "engines": {
-        "node": "20.x.x",
-        "npm": "10.x.x"
+        "node": "^22.x.x",
+        "npm": "^10.x.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.1.30",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-matchmaker-api",
-      "version": "3.1.30",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.83",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "3.1.30",
+  "version": "4.0.0",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "url": "git+https://github.com/digicatapult/sqnc-matchmaker-api.git"
   },
   "engines": {
-    "node": "20.x.x",
-    "npm": "10.x.x"
+    "node": "^22.x.x",
+    "npm": "^10.x.x"
   },
   "keywords": [
     "OpenAPI"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-44

## High level description

Upgrades supported node version to >=22 and supported npm to >=10

## Detailed description

Whilst we were always running on latest lts we previously advertised support for node 20 or higher. We're restricting that now. Technically this is a major version bump as a previously version 20 system would now not be able to run this.

## Describe alternatives you've considered

N/A

## Operational impact

None

## Additional context

N/A
