### PR TITLE
pre-populating role in identity-service

### DIFF
--- a/docker-compose-3-persona.yml
+++ b/docker-compose-3-persona.yml
@@ -29,8 +29,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-matchmaker-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'member-a' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['member-a']
 
   member-a-postgres-identity:
     image: postgres:17.4-alpine
@@ -44,8 +44,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-identity
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'member-a' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['member-a']
 
   member-a-postgres-attachment-api:
     image: postgres:17.4-alpine
@@ -59,11 +59,11 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-attachment-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'member-a' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['member-a']
 
   member-a-identity:
-    image: digicatapult/sqnc-identity-service:v4.1.7
+    image: digicatapult/sqnc-identity-service:v4.2.0
     container_name: member-a-identity
     command: /bin/sh -c "npx knex migrate:latest && npm start"
     depends_on:
@@ -87,7 +87,7 @@ services:
       - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=member-a
       - IDP_INTERNAL_REALM=internal
-    networks: [ 'member-a' ]
+    networks: ['member-a']
 
   member-a-attachment:
     image: digicatapult/sqnc-attachment-api:v2.2.9
@@ -111,7 +111,7 @@ services:
       - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=member-a
       - IDP_INTERNAL_REALM=internal
-    networks: [ 'member-a', 'ipfs' ]
+    networks: ['member-a', 'ipfs']
 
   member-a-node:
     image: digicatapult/sqnc-node:v12.5.0
@@ -122,7 +122,7 @@ services:
     restart: on-failure
     volumes:
       - member-a-node-storage:/data
-    networks: [ 'member-a', 'chain' ]
+    networks: ['member-a', 'chain']
 
   member-a-matchmaker-api:
     container_name: member-a-matchmaker
@@ -166,7 +166,7 @@ services:
       ipfs:
         condition: service_healthy
     restart: on-failure
-    networks: [ 'member-a' ]
+    networks: ['member-a']
 
   # -------------------------------------------------------------------- member-b
   member-b-postgres-matchmaker-api:
@@ -181,8 +181,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-matchmaker-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'member-b' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['member-b']
 
   member-b-postgres-identity:
     image: postgres:17.4-alpine
@@ -196,8 +196,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-identity
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'member-b' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['member-b']
 
   member-b-postgres-attachment-api:
     image: postgres:17.4-alpine
@@ -211,11 +211,11 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-attachment-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'member-b' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['member-b']
 
   member-b-identity:
-    image: digicatapult/sqnc-identity-service:v4.1.7
+    image: digicatapult/sqnc-identity-service:v4.2.0
     container_name: member-b-identity
     command: /bin/sh -c "npx knex migrate:latest && npm start"
     depends_on:
@@ -239,7 +239,7 @@ services:
       - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=member-b
       - IDP_INTERNAL_REALM=internal
-    networks: [ 'member-b' ]
+    networks: ['member-b']
 
   member-b-attachment:
     image: digicatapult/sqnc-attachment-api:v2.2.9
@@ -263,7 +263,7 @@ services:
       - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=member-b
       - IDP_INTERNAL_REALM=internal
-    networks: [ 'member-b', 'ipfs' ]
+    networks: ['member-b', 'ipfs']
 
   member-b-node:
     image: digicatapult/sqnc-node:v12.5.0
@@ -280,7 +280,7 @@ services:
     restart: on-failure
     volumes:
       - member-b-node-storage:/data
-    networks: [ 'member-b', 'chain' ]
+    networks: ['member-b', 'chain']
 
   member-b-matchmaker-api:
     container_name: member-b-matchmaker
@@ -325,7 +325,7 @@ services:
       ipfs:
         condition: service_healthy
     restart: on-failure
-    networks: [ 'member-b' ]
+    networks: ['member-b']
 
   # ------------------------------------------------------------------- optimiser
 
@@ -341,8 +341,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-matchmaker-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'optimiser' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['optimiser']
 
   optimiser-postgres-identity:
     image: postgres:17.4-alpine
@@ -356,8 +356,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-identity
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'optimiser' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['optimiser']
 
   optimiser-postgres-attachment-api:
     image: postgres:17.4-alpine
@@ -371,11 +371,11 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-attachment-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-    networks: [ 'optimiser' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+    networks: ['optimiser']
 
   optimiser-identity:
-    image: digicatapult/sqnc-identity-service:v4.1.7
+    image: digicatapult/sqnc-identity-service:v4.2.0
     container_name: optimiser-identity
     command: /bin/sh -c "npx knex migrate:latest && npm start"
     depends_on:
@@ -399,7 +399,7 @@ services:
       - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=optimiser
       - IDP_INTERNAL_REALM=internal
-    networks: [ 'optimiser' ]
+    networks: ['optimiser']
 
   optimiser-attachment:
     image: digicatapult/sqnc-attachment-api:v2.2.9
@@ -423,7 +423,7 @@ services:
       - IDP_PATH_PREFIX=
       - IDP_OAUTH2_REALM=optimiser
       - IDP_INTERNAL_REALM=internal
-    networks: [ 'optimiser', 'ipfs' ]
+    networks: ['optimiser', 'ipfs']
 
   optimiser-node:
     image: digicatapult/sqnc-node:v12.5.0
@@ -440,7 +440,7 @@ services:
     restart: on-failure
     volumes:
       - optimiser-node-storage:/data
-    networks: [ 'optimiser', 'chain' ]
+    networks: ['optimiser', 'chain']
 
   optimiser-matchmaker-api:
     container_name: optimiser-matchmaker
@@ -485,7 +485,7 @@ services:
       ipfs:
         condition: service_healthy
     restart: on-failure
-    networks: [ 'optimiser' ]
+    networks: ['optimiser']
 
   # ------------------------------------------------------------------------ ipfs
   ipfs:
@@ -500,7 +500,7 @@ services:
       - 4001:4001
       - 8080:8080
       - 5001:5001
-    networks: [ 'ipfs' ]
+    networks: ['ipfs']
     volumes:
       - ipfs:/data/ipfs
 
@@ -516,7 +516,7 @@ services:
     volumes:
       - ./docker/keycloak:/opt/keycloak/data/import
     command: start-dev --import-realm
-    networks: [ 'member-a', 'member-b', 'optimiser' ]
+    networks: ['member-a', 'member-b', 'optimiser']
 
 volumes:
   member-a-matchmaker-api-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-matchmaker-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
 
   postgres-identity-service:
     image: postgres:17.4-alpine
@@ -25,7 +25,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-identity-service
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
 
   postgres-attachment-api:
     image: postgres:17.4-alpine
@@ -39,10 +39,10 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=sqnc-attachment-api
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
 
   sqnc-identity-service:
-    image: digicatapult/sqnc-identity-service:v4.1.7
+    image: digicatapult/sqnc-identity-service:v4.2.0
     container_name: identity-service
     command: /bin/sh -c "npx knex migrate:latest && npm start"
     depends_on:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-matchmaker-api",
-      "version": "6.0.3",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/sqnc-process-management": "^3.0.38",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { LoggerToken } from './lib/logger.js'
 import { Logger } from 'pino'
 
 import ChainNode from './lib/chainNode.js'
+import Identity from './lib/services/identity.js'
+import AuthInternal from './lib/services/authInternal.js'
 ;(async () => {
   // Register singletons in tsyringe
   resetContainer()
@@ -17,10 +19,13 @@ import ChainNode from './lib/chainNode.js'
   const env = container.resolve<Env>(EnvToken)
   const app: Express = await Server()
 
+  const identity = container.resolve<Identity>(Identity)
+  const authInternal = container.resolve<AuthInternal>(AuthInternal)
+  await identity.updateRole('Optimiser', `bearer ${await authInternal.getInternalAccessToken()}`)
+
   if (env.ENABLE_INDEXER) {
     const node = container.resolve(ChainNode)
 
-    // container.registerSingleton(Indexer)
     const indexer = container.resolve(Indexer)
 
     await indexer.start()

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -100,4 +100,20 @@ export default class Identity {
   }
 
   getMemberByAddress = (alias: string, authorization: string) => this.getMemberByAlias(alias, authorization)
+
+  async updateRole(role: string, authorization: string): Promise<void> {
+    const res = await fetch(`${this.URL_PREFIX}/v1/roles/${role}`, {
+      method: 'PUT',
+      headers: {
+        authorization,
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (!res.ok) {
+      throw new HttpResponse({
+        message: 'Failed to update role',
+      })
+    }
+  }
 }

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -109,11 +109,27 @@ export default class Identity {
         'Content-Type': 'application/json',
       },
     })
-
     if (!res.ok) {
       throw new HttpResponse({
         message: 'Failed to update role',
       })
     }
+  }
+
+  async getAllRoles(authorization: string): Promise<string[]> {
+    const res = await fetch(`${this.URL_PREFIX}/v1/roles`, {
+      headers: {
+        authorization,
+      },
+    })
+
+    if (res.ok) {
+      const roles = await res.json()
+      return roles
+    }
+
+    throw new HttpResponse({
+      message: 'Failed to fetch roles',
+    })
   }
 }

--- a/test/integration/onchain/role.test.ts
+++ b/test/integration/onchain/role.test.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai'
+import Identity from '../../../src/lib/services/identity.js'
+import AuthInternal from '../../../src/lib/services/authInternal.js'
+import { container } from 'tsyringe'
+
+describe.only('Identity Service Roles', () => {
+  it('should have only the role Optimiser', async () => {
+    const identity = container.resolve<Identity>(Identity)
+    const authInternal = container.resolve<AuthInternal>(AuthInternal)
+    const token = await authInternal.getInternalAccessToken()
+    await identity.updateRole('Optimiser', `bearer ${token}`)
+    const roles = await identity.getAllRoles(`bearer ${token}`)
+    expect(roles).to.deep.equal(['Optimiser'])
+  })
+})

--- a/test/integration/onchain/role.test.ts
+++ b/test/integration/onchain/role.test.ts
@@ -3,7 +3,7 @@ import Identity from '../../../src/lib/services/identity.js'
 import AuthInternal from '../../../src/lib/services/authInternal.js'
 import { container } from 'tsyringe'
 
-describe.only('Identity Service Roles', () => {
+describe('Identity Service Roles', () => {
   it('should have only the role Optimiser', async () => {
     const identity = container.resolve<Identity>(Identity)
     const authInternal = container.resolve<AuthInternal>(AuthInternal)


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [ ] Chore
- [x] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-131

## High level description

Pre-populate identity service with role 'Optimiser' on startup.
## Detailed description

On startup we now populate Identity-service's database with the `Optimiser` role. this Lins to https://github.com/digicatapult/sqnc-identity-service/pull/474

## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
