### PR TITLE
Fix authz success response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-matchmaker-api",
-      "version": "6.2.2",
+      "version": "6.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/sqnc-process-management": "^3.0.44",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-matchmaker-api",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "An OpenAPI Matchmaking API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/controllers/v1/authz/index.ts
+++ b/src/controllers/v1/authz/index.ts
@@ -12,7 +12,7 @@ import { DemandRow, Match2Row, Where } from '../../../lib/db/types.js'
 
 const success = {
   result: {
-    allowed: true as const,
+    allow: true as const,
   },
 }
 

--- a/src/models/authorization.ts
+++ b/src/models/authorization.ts
@@ -10,6 +10,6 @@ export interface AuthorizationRequest {
 
 export interface AuthorizationResponse {
   result: {
-    allowed: true
+    allow: true
   }
 }

--- a/test/integration/offchain/authz.test.ts
+++ b/test/integration/offchain/authz.test.ts
@@ -288,5 +288,5 @@ describe('authz', () => {
 const assertAuthorized = async (app: Express, request: AuthorizationRequest) => {
   const response = await postInternal(app, '/v1/authz', request)
   expect(response.status).to.equal(200)
-  expect(response.body.result.allowed).to.equal(true)
+  expect(response.body.result.allow).to.equal(true)
 }


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-132

## High level description

Bug fix from #645 

## Detailed description

In #645 the response to the `/v1/authz` request was set incorrectly. The attachment service expects the key to be `allow` not `allowed`

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

N/A
