### PR TITLE
chore: enable trufflehog secret scanning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
       security-events: write
     with:
       matrix_commands: '["lint", "depcheck", "check"]'
+      enable_trufflehog_action: true
   tests-unit:
     uses: digicatapult/shared-workflows/.github/workflows/tests-npm.yml@main
     permissions:


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type
- [x] Chore

## Linked tickets
https://digicatapult.atlassian.net/browse/ENG-292

## High level description
Enables TruffleHog secret scanning in CI as required by the Secure Software Development Policy V1.1 and Software Engineering Standard Secure Development Policy V1.1.

## Detailed description
Adds `enable_trufflehog_action: true` to the existing `static-checks-npm` job in `.github/workflows/test.yml`.

## Describe alternatives you've considered
A standalone `scan-secrets` job was considered but `enable_trufflehog_action: true` is preferred where `static-checks-npm` is already present as it avoids adding a redundant job.

## Operational impact
None — CI-only change.

## Additional context
Part of a compliance audit sweep across the digicatapult org (ENG-292).
